### PR TITLE
Adding dirty indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Visual Studio Live Share Whiteboard
+# Live Share Whiteboard
 
-Visual Studio Live Share Whiteboard enhances the existing Visual Studio Live Share experience, by enabling you to open an integrated whiteboard, without needing to use a seperate tool or service. All participants within a Live Share session can collaboratively draw on the whiteboard, and see each others changes in real-time. For certain use cases (e.g. technical interviews, mentoring/classrooms), this can provide a useful means of communication, in addition to an [audio call](https://aka.ms/vsls-audio) and co-editing and debugging.
+Live Share Whiteboard enhances the existing [Visual Studio Live Share](https://aka.ms/vsls) experience, by enabling you to open an integrated whiteboard, without needing to use a seperate tool or service. All participants within a Live Share session can collaboratively draw on the whiteboard, and see each others changes in real-time. For certain use cases (e.g. technical interviews, mentoring/classrooms), this can provide a useful means of communication, in addition to an [audio call](https://aka.ms/vsls-audio) and co-editing and debugging.
 
 <img width="725px" src="https://user-images.githubusercontent.com/116461/50567457-dddaba00-0cf9-11e9-840b-1b0a984d5ad9.gif" />
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsls-whiteboard",
-  "displayName": "VS Live Share Whiteboard",
+  "displayName": "Live Share Whiteboard",
   "publisher": "lostintangent",
   "description": "Adds a real-time collaborative whiteboard to Visual Studio Live Share sessions",
   "version": "0.0.7",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,11 +3,11 @@ import * as vscode from "vscode";
 import * as vsls from "vsls";
 
 import { createWebView } from "./webView";
-import { registerTreeDataProvider } from "./treeDataProvider";
+import registerTreeDataProvider from "./treeDataProvider";
 
 export async function activate(context: vscode.ExtensionContext) {
   const vslsApi = (await vsls.getApi())!;
-  registerTreeDataProvider(vslsApi);
+  const treeDataProvider = registerTreeDataProvider(vslsApi);
 
   let webviewPanel: vscode.WebviewPanel | null;
   context.subscriptions.push(
@@ -27,7 +27,7 @@ export async function activate(context: vscode.ExtensionContext) {
           ? require("./service/hostService")
           : require("./service/guestService");
 
-      await initializeService(vslsApi, webviewPanel);
+      await initializeService(vslsApi, webviewPanel, treeDataProvider);
     })
   );
 

--- a/src/service/guestService.ts
+++ b/src/service/guestService.ts
@@ -2,10 +2,12 @@ import { WebviewPanel } from "vscode";
 import * as vsls from "vsls";
 
 import initializeBaseService, { SERVICE_NAME } from "./service";
+import { IWhiteboardTreeDataProvider } from "../treeDataProvider";
 
 export default async function(
   vslsApi: vsls.LiveShare,
-  webviewPanel: WebviewPanel
+  webviewPanel: WebviewPanel,
+  treeDataProvider: IWhiteboardTreeDataProvider
 ) {
   const service = await vslsApi.getSharedService(SERVICE_NAME);
   if (!service) return;
@@ -15,5 +17,10 @@ export default async function(
     webviewPanel.webview.postMessage({ command: "loadSnapshot", data });
   }, 500);
 
-  initializeBaseService(vslsApi.session.peerNumber, service, webviewPanel);
+  initializeBaseService(
+    vslsApi.session.peerNumber,
+    service,
+    webviewPanel,
+    treeDataProvider
+  );
 }

--- a/src/service/hostService.ts
+++ b/src/service/hostService.ts
@@ -2,10 +2,12 @@ import { WebviewPanel } from "vscode";
 import * as vsls from "vsls";
 
 import initializeBaseService, { SERVICE_NAME } from "./service";
+import { IWhiteboardTreeDataProvider } from "../treeDataProvider";
 
 export default async function(
   vslsApi: vsls.LiveShare,
-  webviewPanel: WebviewPanel
+  webviewPanel: WebviewPanel,
+  treeDataProvider: IWhiteboardTreeDataProvider
 ) {
   const service = await vslsApi.shareService(SERVICE_NAME);
   if (!service) return;
@@ -22,6 +24,7 @@ export default async function(
     vslsApi.session.peerNumber,
     service,
     webviewPanel,
+    treeDataProvider,
     true
   );
   baseService.setCustomWebviewHandler((command: string, data: any) => {

--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -1,5 +1,6 @@
 import { WebviewPanel } from "vscode";
 import { SharedService, SharedServiceProxy } from "vsls";
+import { IWhiteboardTreeDataProvider } from "../treeDataProvider";
 
 interface Message {
   data?: any;
@@ -27,6 +28,7 @@ export default function(
   peer: number,
   service: SharedService | SharedServiceProxy,
   webviewPanel: WebviewPanel,
+  treeDataProvider: IWhiteboardTreeDataProvider,
   broadcastNotifications: boolean = false
 ) {
   NOTIFICATIONS.forEach(commandName => {
@@ -41,6 +43,7 @@ export default function(
       if (webviewPanel.visible) {
         webviewPanel.webview.postMessage(webviewMessage);
       } else {
+        treeDataProvider.updateWhiteboardState(true);
         pendingWebviewMessages.push(webviewMessage);
       }
 
@@ -56,6 +59,7 @@ export default function(
       while ((message = pendingWebviewMessages.shift())) {
         webviewPanel.webview.postMessage(message);
       }
+      treeDataProvider.updateWhiteboardState(false);
     }
   });
 

--- a/src/treeDataProvider.ts
+++ b/src/treeDataProvider.ts
@@ -1,24 +1,52 @@
-import { Command, ProviderResult, TreeDataProvider, TreeItem } from "vscode";
+import {
+  Command,
+  Event,
+  EventEmitter,
+  ProviderResult,
+  TreeDataProvider,
+  TreeItem
+} from "vscode";
 import { LiveShare, View } from "vsls";
 
-const DATA_PROVIDER: TreeDataProvider<Command> = {
+export interface IWhiteboardTreeDataProvider extends TreeDataProvider<Command> {
+  updateWhiteboardState(isDirty: boolean): void;
+}
+
+const LABEL_PREFIX = "Whiteboard";
+
+class WhiteboardTreeDataProvider implements IWhiteboardTreeDataProvider {
+  private _treeCommand: Command = {
+    command: "liveshare.openWhiteboard",
+    title: LABEL_PREFIX
+  };
+
+  private _onDidChangeTreeData = new EventEmitter<Command>();
+  public readonly onDidChangeTreeData: Event<Command> = this
+    ._onDidChangeTreeData.event;
+
   getChildren(element?: Command): ProviderResult<Command[]> {
-    return Promise.resolve([
-      {
-        command: "liveshare.openWhiteboard",
-        title: "Whiteboard"
-      }
-    ]);
-  },
+    return Promise.resolve([this._treeCommand]);
+  }
+
   getTreeItem(element: Command): TreeItem {
-    const treeItem = new TreeItem("Whiteboard");
-    treeItem.contextValue = "whiteboard";
+    const treeItem = new TreeItem(LABEL_PREFIX);
+    treeItem.label = element.title;
+    treeItem.contextValue = LABEL_PREFIX;
     treeItem.command = element;
     return treeItem;
   }
-};
 
-export function registerTreeDataProvider(vslsApi: LiveShare) {
-  vslsApi.registerTreeDataProvider(View.Session, DATA_PROVIDER);
-  vslsApi.registerTreeDataProvider(View.ExplorerSession, DATA_PROVIDER);
+  updateWhiteboardState(isDirty: boolean) {
+    const suffix = isDirty ? " (*)" : "";
+    this._treeCommand.title = `${LABEL_PREFIX}${suffix}`;
+    this._onDidChangeTreeData.fire(this._treeCommand);
+  }
+}
+
+export default function(vslsApi: LiveShare) {
+  const treeDataProvider = new WhiteboardTreeDataProvider();
+  vslsApi.registerTreeDataProvider(View.Session, treeDataProvider);
+  vslsApi.registerTreeDataProvider(View.ExplorerSession, treeDataProvider);
+
+  return treeDataProvider;
 }


### PR DESCRIPTION
This PR simply adds a "dirty indicator" to the `Whiteboard` node in the Live Share tree, so that if you have the whiteboard in a background tab, and another participant makes changes to it, you'll know.

<img width="166" alt="Screen Shot 2019-04-01 at 2 20 48 PM" src="https://user-images.githubusercontent.com/116461/55360718-140b0f80-548a-11e9-8fe7-207da2cbef6c.png">
