### PR TITLE
Support extension to be hosted on the web and using a new liveshare API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist
+dist-web
 node_modules
 *.vsix
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vsls-whiteboard",
-	"version": "0.0.7",
+	"version": "0.0.9",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1925,7 +1925,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -1946,12 +1947,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -1966,17 +1969,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -2093,7 +2099,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -2105,6 +2112,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -2119,6 +2127,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -2126,12 +2135,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -2150,6 +2161,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -2230,7 +2242,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -2242,6 +2255,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -2327,7 +2341,8 @@
 				"safe-buffer": {
 					"version": "5.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -2363,6 +2378,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -2382,6 +2398,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -2425,12 +2442,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   "scripts": {
     "vscode:prepublish": "npm run compile",
     "compile": "webpack",
+    "compile-web": "webpack --config webpack.browser.config",
     "watch": "webpack --watch",
     "postinstall": "node ./node_modules/vscode/bin/install"
   },

--- a/src/abstractions/browser/fileAccess.ts
+++ b/src/abstractions/browser/fileAccess.ts
@@ -1,0 +1,9 @@
+import { Uri } from 'vscode';
+
+class FileAccess {
+    public writeFile(uri: Uri, data: any): Promise<void> {
+        throw new Error('not supported in browser');
+    }
+}
+
+export const fileAccess = new FileAccess();

--- a/src/abstractions/node/fileAccess.ts
+++ b/src/abstractions/node/fileAccess.ts
@@ -1,0 +1,15 @@
+import { Uri } from 'vscode';
+import * as fs from "fs";
+
+class FileAccess {
+    public writeFile(uri: Uri, data: any): Promise<void> {
+        return new Promise(function (resolve, reject) {
+            fs.writeFile(uri.toString().replace("file://", ""), data, function (err) {
+                if (err) reject(err);
+                else resolve();
+            });
+        });
+    }
+}
+
+export const fileAccess = new FileAccess();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,14 @@
-import * as fs from "fs";
 import * as vscode from "vscode";
 import * as vsls from "vsls";
+import { fileAccess } from '@file-abstractions/fileAccess';
 
 import { createWebView } from "./webView";
 import registerTreeDataProvider from "./treeDataProvider";
 
+const extensionId = 'lostintangent.vsls-whiteboard';
+
 export async function activate(context: vscode.ExtensionContext) {
-  const vslsApi = (await vsls.getApi())!;
+  const vslsApi = (await vsls.getApi(extensionId))!;
   const treeDataProvider = registerTreeDataProvider(vslsApi);
 
   let webviewPanel: vscode.WebviewPanel | null;
@@ -49,9 +51,9 @@ export async function activate(context: vscode.ExtensionContext) {
         });
         if (!uri) return;
 
-        webviewPanel.webview.onDidReceiveMessage(({ command, data }) => {
+        webviewPanel.webview.onDidReceiveMessage(async ({ command, data }) => {
           if (command === "snapshotSVGResponse") {
-            fs.writeFileSync(uri.toString().replace("file://", ""), data);
+            await fileAccess.writeFile(uri, data);
           }
         });
         await webviewPanel.webview.postMessage({ command: "getSnapshotSVG" });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,11 +3,20 @@
     "module": "commonjs",
     "target": "es2017",
     "outDir": "dist",
-    "lib": ["es6"],
+    "lib": [
+      "es6"
+    ],
     "sourceMap": true,
     "strict": true,
     "noUnusedLocals": true,
-    "rootDir": "./src"
+    "baseUrl": "./src",
+    "paths": {
+      "@file-abstractions/*": [
+        "abstractions/node/*"
+      ]
+    }
   },
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/webpack.browser.config.js
+++ b/webpack.browser.config.js
@@ -4,7 +4,7 @@ module.exports = {
   entry: "./src/extension.ts",
   devtool: "source-map",
   mode: "development",
-  target: "node",
+  target: "webworker",
   module: {
     rules: [
       {
@@ -19,13 +19,13 @@ module.exports = {
   resolve: {
     extensions: [".ts", ".js"],
     alias: {
-      '@file-abstractions': path.join(__dirname, './src/abstractions/node')
+      '@file-abstractions': path.join(__dirname, './src/abstractions/browser')
     }
   },
   output: {
     filename: "bundle.js",
     libraryTarget: "commonjs2",
-    path: path.resolve(__dirname, "dist"),
+    path: path.resolve(__dirname, "dist-web"),
     devtoolModuleFilenameTemplate: "file:///[absolute-resource-path]"
   }
 };


### PR DESCRIPTION
The project now can be compiled against the browser usign the webpack tool.
We are using a newer version of the liveshare API to pass the optional extension id so the liveshare web extension is able to track the package info to properly register service names.
Other important changes are related on how to locate the 'static' assets require by the vscode web view panel.