### PR TITLE
Activate on openWhiteboard and added condition to initialize service …

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "onCommand:liveshare.startReadOnlyFromActivityBar",
     "onCommand:liveshare.startReadOnlyFromSessionExplorer",
     "onCommand:liveshare.inviteUserJoin",
-    "onCommand:liveshare.inviteUserJoinByEmail"
+    "onCommand:liveshare.inviteUserJoinByEmail",
+    "onCommand:liveshare.openWhiteboard"
   ],
   "main": "./dist/bundle.js",
   "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,7 +25,7 @@ export async function activate(context: vscode.ExtensionContext) {
       }
 
       let { default: initializeService } =
-        vslsApi.session.role === vsls.Role.Host
+        (vslsApi.session.role === vsls.Role.None || vslsApi.session.role === vsls.Role.Host)
           ? require("./service/hostService")
           : require("./service/guestService");
 


### PR DESCRIPTION
- Activate on openWhiteboard command 
(Need: Interview service needs the whiteboard to be opened before the Liveshare session has started so that the interviewer can set up/draw before he starts the interview (ie before he starts the Liveshare session))

- Added condition to initialize service as Host when Role equals None 
(Need: The changes made to the whiteboard before the liveshare session has started needs to be communicated)